### PR TITLE
task: Bump version to 0.1.0-alpha4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Upcoming changes.
 
 ### Removed
 
-## [0.0.1-alpha3] - 2020-06-09
+## [0.1.0-alpha4] - 2020-06-09
 
 Initial alpha release
 
@@ -41,5 +41,5 @@ Initial alpha release
 These Markdown anchors provide a link to the diff for each release. They should be
 updated any time a new release is cut.
 -->
-[Unreleased]: https://github.com/timoguin/aws-org-tools-py/compare/v0.0.1-alpha3...HEAD
-[0.0.1-alpha3]: https://github.com/timoguin/aws-org-tools-py/releases/tag/v0.0.1-alpha3
+[Unreleased]: https://github.com/timoguin/aws-org-tools-py/compare/v0.1.0-alpha4...HEAD
+[0.1.0-alpha4]: https://github.com/timoguin/aws-org-tools-py/releases/tag/v0.1.0-alpha4

--- a/aws_data_tools/__init__.py
+++ b/aws_data_tools/__init__.py
@@ -7,7 +7,7 @@ from botocore.paginate import PageIterator, Paginator
 from humps import depascalize, pascalize
 
 
-__VERSION__ = "0.1.0-alpha3"
+__VERSION__ = "0.1.0-alpha4"
 
 
 _DEFAULT_PAGINATION_CONFIG = {"MaxItems": 500}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws_data_tools"
-version = "0.1.0-alpha3"
+version = "0.1.0-alpha4"
 description = "A set of Python libraries for querying and transforming data from AWS APIs"
 authors = ["Tim O'Guin <timoguin@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Due to a mistake with version info in the CHANGELOG that was caught after publishing,
this bumps the version.
