### PR TITLE
feat(cli): Add an organization lookup-accounts command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ the unreleased section to the section for the new release.
 
 No unreleased changes.
 
+### Added
+
+- Adds an `organization lookup-accounts` CLI command
+- Adds a `field` argument to `ModelBase.as_dict()` to dump a single field in a model
+- Adds configurations for tox and other testing tools
+
+### Changed
+
+- Refactors `OrganizationDataBuilder` to allow more control over pulling data
+
 ## [0.1.0-beta1] - 2020-06-09
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,22 @@ shell: ${VENV_DIR}
 shellcmd: ${VENV_DIR}
 	@${SHELL_CMD_PREFIX} /bin/bash -c "poetry run ${CMD}"
 
+.PHONY: lint
+lint:
+	@if [ -z $$VIRTUAL_ENV ]; then       \
+	     poetry run tox --quiet -e lint; \
+	 else                                \
+	     tox --quiet -e lint;            \
+	 fi
+
+.PHONY: lint-docs
+lint-docs:
+	@if [ -z $$VIRTUAL_ENV ]; then            \
+	     poetry run tox --quiet -e lint-docs; \
+	 else                                     \
+	     tox --quiet -e lint-docs;            \
+	 fi
+
 .PHONY: test-integration ## Run the integration test suite
 test-integration: run-test-server
 	@printf "${OK}%s...\n${CCEND}" "Starting motoserver"

--- a/aws_data_tools/__init__.py
+++ b/aws_data_tools/__init__.py
@@ -1,3 +1,7 @@
+"""
+A library for working with data from AWS APIs
+"""
+
 __VERSION__ = "0.1.0-beta1"
 
 

--- a/aws_data_tools/cli/TODO.md
+++ b/aws_data_tools/cli/TODO.md
@@ -1,0 +1,1 @@
+Fix new tag functions that were refactored and now broke

--- a/aws_data_tools/cli/__init__.py
+++ b/aws_data_tools/cli/__init__.py
@@ -1,14 +1,16 @@
+"""
+CLI interface for working with data from AWS APIs
+"""
+
 from json import dumps as json_dumps
-from sys import stdout
+from re import fullmatch
 from traceback import format_exc
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 from botocore.exceptions import ClientError, NoCredentialsError
-from structlog import configure, processors, dev, get_logger
 from yaml import dump as yaml_dump
 
 from click import (
-    argument,
     command,
     echo,
     group,
@@ -18,26 +20,10 @@ from click import (
     secho,
     version_option,
     Choice,
-    Path,
 )
 
 from .. import get_version
-from ..builders.organizations import OrganizationDataBuilder as odb
-
-
-configure(
-    processors=[
-        processors.add_log_level,
-        processors.StackInfoRenderer(),
-        dev.set_exc_info,
-        processors.format_exc_info,
-        processors.TimeStamper(),
-        processors.JSONRenderer(),
-        dev.ConsoleRenderer(),
-    ],
-    cache_logger_on_first_use=True,
-)
-log = get_logger()
+from ..builders.organizations import OrganizationDataBuilder
 
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -60,9 +46,10 @@ def organization(ctx):
     ctx.ensure_object(dict)
 
 
-def handle_error(ctx, errmsg, tb):
-    if errmsg is not None:
-        secho(errmsg, fg="red")
+def handle_error(ctx, err_msg, tb=None):
+    """Takes an error message and an optional traceback, prints them, and quits"""
+    if err_msg is not None:
+        secho(err_msg, fg="red")
         if tb is not None:
             echo()
             secho(tb, fg="red")
@@ -85,6 +72,7 @@ def handle_error(ctx, errmsg, tb):
 @option(
     "--format",
     "-f",
+    "format_",
     default="JSON",
     type=Choice(["JSON", "YAML"], case_sensitive=False),
     help="The output format for the data",
@@ -95,11 +83,11 @@ def dump_json(
     ctx: Dict[str, Any],
     no_accounts: bool,
     no_policies: bool,
-    format: str,
+    format_: str,
     out_file: str,
 ) -> Union[str, None]:
     """Dump a JSON representation of the organization"""
-    errmsg = None
+    err_msg = None
     tb = None
     try:
         kwargs = {"init_all": True}
@@ -115,23 +103,105 @@ def dump_json(
             kwargs["init_policy_tags"] = False
             kwargs["init_policy_targets"] = False
         org = odb(**kwargs)
-        if format == "JSON":
+        if format_ == "JSON":
             s_func = org.as_json
-        elif format == "YAML":
+        elif format_ == "YAML":
             s_func = org.as_yaml
-        data = s_func()
         if out_file is None:
             out_file = "-"
         with open_file(out_file, mode="wb") as f:
             f.write(bytes(s_func(), "utf-8"))
     except ClientError as exc_info:
-        errmsg = f"Service Error: {str(exc_info)}"
+        err_msg = f"Service Error: {str(exc_info)}"
     except NoCredentialsError as exc_info:
-        errmsg = f"Error: Unable to locate AWS credentials"
+        err_msg = f"Error: Unable to locate AWS credentials"
     except Exception as exc_info:
-        errmsg = f"Unknown Error: {str(exc_info)}"
+        err_msg = f"Unknown Error: {str(exc_info)}"
         tb = format_exc()
-    handle_error(ctx, errmsg, tb)
+    handle_error(ctx, err_msg, tb)
+
+
+@organization.command(short_help="Query for account details")
+@option("--accounts", "-a", required=True, help="A space-delimited list of account IDs")
+@option(
+    "--include-effective-policies",
+    default=False,
+    is_flag=True,
+    help="Include effective policies for the accounts",
+)
+@option(
+    "--include-parents",
+    default=False,
+    is_flag=True,
+    help="Include parent data for the accounts",
+)
+@option(
+    "--include-tags",
+    default=False,
+    is_flag=True,
+    help="Include tags applied to the accounts",
+)
+@option(
+    "--include-policies",
+    default=False,
+    is_flag=True,
+    help="Include policies attached to the accounts",
+)
+@pass_context
+def lookup_accounts(
+    ctx: Dict[str, Any],
+    accounts: List[str],
+    include_parents: bool,
+    include_effective_policies: bool,
+    include_policies: bool,
+    include_tags: bool,
+) -> str:
+    """Query for account details using a list of account IDs"""
+    accounts_unvalidated = []
+    if " " in accounts:
+        accounts_unvalidated = accounts.split(" ")
+    else:
+        account_unvalidated = [accounts]
+    account_ids = []
+    invalid_ids = []
+    for account in accounts_unvalidated:
+        if fullmatch(r"^[\d]{12}$", account) is not None:
+            account_ids.append(account)
+        else:
+            invalid_ids.append(account)
+    if len(invalid_ids) > 0:
+        handle_error(
+            ctx,
+            f"Invalid account IDs included in request: {str.join(' ', invalid_ids)}",
+        )
+    odb = OrganizationDataBuilder()
+    odb.Connect()
+    odb.fetch_accounts(include_parents=include_parents)
+
+    exclude_keys = []
+    if not include_parents:
+        exclude_keys.append("parent")
+    if not include_policies:
+        exclude_keys.append("policies")
+    if not include_effective_policies:
+        exclude_keys.append("effective_policies")
+    if not include_tags:
+        exclude_keys.append("tags")
+
+    if include_policies:
+        odb.fetch_policies()
+        odb.fetch_policy_targets()
+    if include_effective_policies:
+        odb.fetch_effective_policies(account_ids=account_ids)
+    if include_tags:
+        odb.fetch_account_tags(account_ids=account_ids)
+
+    data = [
+        {k: v for k, v in acct.as_dict().items() if k not in exclude_keys}
+        for acct in odb.dm.accounts
+        if acct.id in account_ids
+    ]
+    echo(json_dumps(data, default=str))
 
 
 if __name__ == "__main__":

--- a/aws_data_tools/client.py
+++ b/aws_data_tools/client.py
@@ -1,9 +1,13 @@
-from dataclasses import dataclass, field, InitVar
-from typing import Any, ClassVar, Dict, List, Union
+"""
+Module containing classes that abstract interactions with boto3 sessions and clients
+"""
+
+from dataclasses import dataclass, field
+from json import dumps as json_dumps
+from typing import Any, Dict, List, Union
 
 from boto3.session import Session
 from botocore.client import BaseClient
-from botocore.paginate import PageIterator, Paginator
 from humps import depascalize, pascalize
 
 
@@ -44,9 +48,9 @@ class APIClient:
                 key = [k for k in page.keys() if k not in metakeys][0]
                 responses.extend(page.get(key))
             return responses
-        else:
-            response = getattr(self.client, func)(**kwargs)
-            return depascalize(response)
+        # TODO: Fix logging to use structlog globally
+        response = getattr(self.client, func)(**kwargs)
+        return depascalize(response)
 
     def __post_init__(self):
         self.client = self.session.client(self.service)

--- a/aws_data_tools/models/__init__.py
+++ b/aws_data_tools/models/__init__.py
@@ -1,17 +1,39 @@
-from dataclasses import asdict, dataclass, is_dataclass
+"""
+Package containing dataclass representations of AWS API data
+"""
+
+from dataclasses import asdict, dataclass, fields, is_dataclass
 from json import dumps as json_dumps
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 from yaml import dump as yaml_dump
 
 
 @dataclass
 class ModelBase:
-    def as_dict(self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if not k.startswith("_")}
+    """Base class for all models with helpers for serialization"""
 
-    def as_json(self) -> str:
-        return json_dumps(self.as_dict(), default=str)
+    def as_dict(
+        self, field_name: str = None
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """
+        Serialize the dataclass instance to a dict, or serialize a single field. If the
+        field is a collection, it is returned as such. If the field is a simple type,
+        it is returned as a k/v dict.
+        """
+        data = {k: v for k, v in asdict(self).items() if not k.startswith("_")}
+        if field_name is not None:
+            if field_name in data.keys():
+                if type(data[field_name]) in [dict, list]:
+                    return data[field_name]
+                return {field_name: data[field_name]}
+            raise Exception(f"Field {field_name} does not exist")
+        return data
 
-    def as_yaml(self) -> str:
-        return yaml_dump(self.as_dict())
+    def as_json(self, **kwargs) -> str:
+        """Serialize the dataclass instance to JSON"""
+        return json_dumps(self.as_dict(**kwargs), default=str)
+
+    def as_yaml(self, **kwargs) -> str:
+        """Serialize the dataclass instance to YAML"""
+        return yaml_dump(self.as_dict(**kwargs))

--- a/aws_data_tools/models/organizations.py
+++ b/aws_data_tools/models/organizations.py
@@ -1,10 +1,11 @@
-from dataclasses import asdict, dataclass, field
-from json import dumps as json_dumps
-from typing import Any, Dict, List, Union
+"""
+Dataclass models for working with AWS Organizations APIs
+"""
 
-from yaml import dump as yaml_dump
+from dataclasses import dataclass, field
+from typing import Dict, List
 
-from .. import ModelBase
+from . import ModelBase
 
 
 @dataclass
@@ -65,6 +66,8 @@ class PolicyTypeSummary(ModelBase):
 
 @dataclass
 class Policy(ModelBase):
+    """A policy in an organization"""
+
     policy_summary: PolicySummary
 
     # We allow content to be None because ListPolicies doesn't return the content data.
@@ -76,6 +79,7 @@ class Policy(ModelBase):
     targets: List[PolicyTargetSummary] = field(default=None)
 
     def as_target(self):
+        """Return the Policy as a PolicySummaryForTarget object"""
         return PolicySummaryForTarget(
             id=self.policy_summary.id, type=self.policy_summary.type
         )
@@ -83,6 +87,8 @@ class Policy(ModelBase):
 
 @dataclass
 class Root(ModelBase):
+    """The root in an organization"""
+
     arn: str
     id: str
     name: str
@@ -93,9 +99,11 @@ class Root(ModelBase):
     policies: List[PolicySummaryForTarget] = field(default=None)
 
     def as_parchild_dict(self) -> Dict[str, str]:
+        """Return the root as a ParChild (parent) dict"""
         return {"id": self.id, "type": "ROOT"}
 
     def as_parchild(self) -> ParChild:
+        """Return the root as a ParChild (parent) object"""
         return ParChild(**self.as_parchild_dict())
 
 
@@ -114,9 +122,11 @@ class OrganizationalUnit(ModelBase):
     tags: Dict[str, str] = field(default=None)
 
     def as_parchild_dict(self) -> Dict[str, str]:
+        """Return the OU as a ParChild (parent) dict"""
         return {"id": self.id, "type": "ORGANIZATIONAL_UNIT"}
 
     def as_parchild(self) -> ParChild:
+        """Return the OU as a ParChild (parent) object"""
         return ParChild(**self.as_parchild_dict())
 
 
@@ -139,9 +149,11 @@ class Account(ModelBase):
     tags: Dict[str, str] = field(default=None)
 
     def as_parchild_dict(self) -> Dict[str, str]:
+        """Return the account as a ParChild (parent) dict"""
         return {"id": self.id, "type": "ACCOUNT"}
 
     def as_parchild(self) -> ParChild:
+        """Return the account as a ParChild (parent) object"""
         return ParChild(**self.as_parchild_dict())
 
 

--- a/aws_data_tools/utils.py
+++ b/aws_data_tools/utils.py
@@ -7,6 +7,7 @@ from .client import APIClient
 
 
 def tag_list_to_dict(tags: List[Dict[str, str]]) -> Dict[str, str]:
+    """Convert a list of tag objects to a dict"""
     return {tag["key"]: tag["value"] for tag in tags}
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,18 @@ docs = ["sphinx"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
+name = "astroid"
+version = "2.5.6"
+description = "An abstract syntax tree for Python with inference support."
+category = "dev"
+optional = false
+python-versions = "~=3.6"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0"
+wrapt = ">=1.11,<1.13"
+
+[[package]]
 name = "async-generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
@@ -234,6 +246,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
 name = "ghp-import"
 version = "2.0.1"
 description = "Copy your docs directly to the gh-pages branch."
@@ -375,6 +400,19 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "isort"
+version = "5.8.0"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+
+[[package]]
 name = "jedi"
 version = "0.18.0"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -472,6 +510,14 @@ python-versions = "*"
 pygments = ">=2.4.1,<3"
 
 [[package]]
+name = "lazy-object-proxy"
+version = "1.6.0"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
 name = "markdown"
 version = "3.3.4"
 description = "Python implementation of Markdown."
@@ -500,6 +546,14 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "mergedeep"
@@ -843,11 +897,27 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pycparser"
 version = "2.20"
 description = "C parser in Python"
 category = "main"
 optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -865,6 +935,21 @@ description = "🐫  Convert strings (and dictionary keys) between snake case, c
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pylint"
+version = "2.8.3"
+description = "python code static checker"
+category = "dev"
+optional = false
+python-versions = "~=3.6"
+
+[package.dependencies]
+astroid = "2.5.6"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+isort = ">=4.2.5,<6"
+mccabe = ">=0.6,<0.7"
+toml = ">=0.7.1"
 
 [[package]]
 name = "pymdown-extensions"
@@ -1113,6 +1198,22 @@ docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-a
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
+name = "tox-poetry"
+version = "0.4.0"
+description = "Tox poetry plugin"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pluggy = "*"
+toml = "*"
+tox = {version = ">=3.7.0", markers = "python_version >= \"3\""}
+
+[package.extras]
+test = ["coverage", "pytest", "pycodestyle", "pylint"]
+
+[[package]]
 name = "traitlets"
 version = "5.0.5"
 description = "Traitlets Python configuration system"
@@ -1185,6 +1286,14 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "zipp"
 version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1204,7 +1313,7 @@ docs = ["blacken-docs", "mkdocs", "mkdocs-git-revision-date-localized-plugin", "
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<4"
-content-hash = "f32eea71887f276753243309e0ed2e6376c46ae30bb9247d221348a42d6b56c9"
+content-hash = "12e9f959b4c4c24ed6d54f9ece65dc360e70029206cba6dfda332d6e3ac75029"
 
 [metadata.files]
 appdirs = [
@@ -1234,6 +1343,10 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
+]
+astroid = [
+    {file = "astroid-2.5.6-py3-none-any.whl", hash = "sha256:4db03ab5fc3340cf619dbc25e42c2cc3755154ce6009469766d7143d1fc2ee4e"},
+    {file = "astroid-2.5.6.tar.gz", hash = "sha256:8a398dfce302c13f14bab13e2b14fe385d32b73f4e4853b9bdfb64598baa1975"},
 ]
 async-generator = [
     {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
@@ -1346,6 +1459,10 @@ filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
 ghp-import = [
     {file = "ghp-import-2.0.1.tar.gz", hash = "sha256:753de2eace6e0f7d4edfb3cce5e3c3b98cd52aadb80163303d1d036bda7b4483"},
 ]
@@ -1384,6 +1501,10 @@ ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
+isort = [
+    {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
+    {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
+]
 jedi = [
     {file = "jedi-0.18.0-py2.py3-none-any.whl", hash = "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93"},
     {file = "jedi-0.18.0.tar.gz", hash = "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"},
@@ -1411,6 +1532,30 @@ jupyter-core = [
 jupyterlab-pygments = [
     {file = "jupyterlab_pygments-0.1.2-py2.py3-none-any.whl", hash = "sha256:abfb880fd1561987efaefcb2d2ac75145d2a5d0139b1876d5be806e32f630008"},
     {file = "jupyterlab_pygments-0.1.2.tar.gz", hash = "sha256:cfcda0873626150932f438eccf0f8bf22bfa92345b814890ab360d666b254146"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.6.0.tar.gz", hash = "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win32.whl", hash = "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win32.whl", hash = "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win32.whl", hash = "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"},
 ]
 markdown = [
     {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
@@ -1455,6 +1600,10 @@ markupsafe = [
 matplotlib-inline = [
     {file = "matplotlib-inline-0.1.2.tar.gz", hash = "sha256:f41d5ff73c9f5385775d5c0bc13b424535c8402fe70ea8210f93e11f3683993e"},
     {file = "matplotlib_inline-0.1.2-py3-none-any.whl", hash = "sha256:5cf1176f554abb4fa98cb362aa2b55c500147e4bdbb07e3fda359143e1da0811"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mergedeep = [
     {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
@@ -1559,9 +1708,17 @@ py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygments = [
     {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
@@ -1570,6 +1727,10 @@ pygments = [
 pyhumps = [
     {file = "pyhumps-3.0.2-py3-none-any.whl", hash = "sha256:367b1aadcaa64f8196a3cd14f56559a5602950aeb8486f49318e7394f5e18052"},
     {file = "pyhumps-3.0.2.tar.gz", hash = "sha256:042b4b6eec6c1f862f8310c0eebbae19293e9edab8cafb030ff78c890ef1aa34"},
+]
+pylint = [
+    {file = "pylint-2.8.3-py3-none-any.whl", hash = "sha256:792b38ff30903884e4a9eab814ee3523731abd3c463f3ba48d7b627e87013484"},
+    {file = "pylint-2.8.3.tar.gz", hash = "sha256:0a049c5d47b629d9070c3932d13bff482b12119b6a241a93bc460b0be16953c8"},
 ]
 pymdown-extensions = [
     {file = "pymdown-extensions-8.2.tar.gz", hash = "sha256:b6daa94aad9e1310f9c64c8b1f01e4ce82937ab7eb53bfc92876a97aca02a6f4"},
@@ -1807,6 +1968,10 @@ tox = [
     {file = "tox-3.23.1-py2.py3-none-any.whl", hash = "sha256:b0b5818049a1c1997599d42012a637a33f24c62ab8187223fdd318fa8522637b"},
     {file = "tox-3.23.1.tar.gz", hash = "sha256:307a81ddb82bd463971a273f33e9533a24ed22185f27db8ce3386bff27d324e3"},
 ]
+tox-poetry = [
+    {file = "tox-poetry-0.4.0.tar.gz", hash = "sha256:b926723cb1dea87902299dd8cad458d0b80ab7345bbf7983e6dab1cbf951090d"},
+    {file = "tox_poetry-0.4.0-py2.py3-none-any.whl", hash = "sha256:b529f3b534b351b7cf9506caa66e2f230dded38b2b74245559c3d662685f4494"},
+]
 traitlets = [
     {file = "traitlets-5.0.5-py3-none-any.whl", hash = "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"},
     {file = "traitlets-5.0.5.tar.gz", hash = "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396"},
@@ -1845,6 +2010,9 @@ wcwidth = [
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 zipp = [
     {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,11 @@ mkdocs-material = {version = "^7.1.5", optional = true, extras = ["docs"]}
 
 [tool.poetry.dev-dependencies]
 black = "^21.5b1"
+flake8 = "^3.9.2"
+isort = "^5.8.0"
+pylint = "^2.8.3"
 pytest = "^6.2.4"
-tox = "^3.23.1"
+tox-poetry = "^0.4.0"
 
 [tool.poetry.extras]
 cli = ["click"]
@@ -75,3 +78,9 @@ awsdata = "aws_data_tools.cli:cli"
 [build-system]
 requires = ["poetry-core>=1.0.3"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py39
+
+[testenv:lint]
+commands =
+	black .
+    pylint aws_data_tools
+
+[testenv:lint-docs]
+commands =
+    blacken-docs *.md


### PR DESCRIPTION
### Added

- Adds an `organization lookup-accounts` CLI command
- Adds a `field` argument to `ModelBase.as_dict()` to dump a single field in a model
- Adds configurations for tox and other testing tools

### Changed

- Refactors `OrganizationDataBuilder` to allow more control over pulling data
