### PR TITLE
feat(cli): Commands to read/write AWS Accounts in DynamoDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,21 @@ No unreleased changes.
 - Adds a `field` argument to `ModelBase.as_dict()` to dump a single field in a model
 - Adds configurations for tox and other testing tools
 - Adds a quickstart to the top of the README
+- Adds an `organizations write-accounts-to-dynamodb` CLI command
+- Adds an `organizations read-accounts-from-dynamodb` CLI command
+- Adds DynamoDB (de)serialization functions and requests helpers to utils
 
 ### Changed
 
 - Refactors `OrganizationDataBuilder` to allow more control over pulling data
+- Updates the Makefile to allow setting a custom PYTHONBREAKPOINT when debugging
+- Updates `OrganizationDataBuilder` to allow setting the client during init
+- Updates `OrganizationDataBuilder` to allow excluding account parent data lookups
+- Renames `ModelBase` serialization function prefixes from `as_` to `to_`
+- Updates `APIClient.api()` to only pascalize keys in kwargs, not the values. This
+  fixes a bug that was causing items being inserted into DynamoDB to be pascalized.
+- Updates `APIClient()` and `APIClient.Connect()` to skip creating the client if it
+  already exists
 
 ## [0.1.0-beta1] - 2020-06-09
 

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,10 @@ PY_INSTALL_ARGS ?=--extras="cli devtools docs"
 VENV_DIR ?=.venv
 CMD ?=/bin/bash
 DEBUG ?=false
+PYTHONBREAKPOINT ?=ipdb.set_trace
 
 ifeq (${DEBUG},true)
-	export PYTHONBREAKPOINT=ipdb.set_trace
+	export PYTHONBREAKPOINT
 else
 	export PYTHONBREAKPOINT=0
 endif

--- a/aws_data_tools/client.py
+++ b/aws_data_tools/client.py
@@ -33,7 +33,7 @@ class APIClient:
         If the API action is one that supports pagination, it is handled automaticaly.
         All paginated responses are fully aggregated and then returned.
         """
-        kwargs = pascalize(kwargs)
+        kwargs = {pascalize(key): value for key, value in kwargs.items()}
         paginate = self.client.can_paginate(func)
         if paginate:
             paginator = self.client.get_paginator(func)
@@ -52,4 +52,5 @@ class APIClient:
         return depascalize(response)
 
     def __post_init__(self):
-        self.client = self.session.client(self.service)
+        if self.client is None:
+            self.client = self.session.client(self.service)

--- a/aws_data_tools/models/base.py
+++ b/aws_data_tools/models/base.py
@@ -8,12 +8,14 @@ from typing import Any, Dict, List, Union
 
 from yaml import dump as yaml_dump
 
+from ..utils import serialize_dynamodb_item, serialize_dynamodb_items
+
 
 @dataclass
 class ModelBase:
     """Base class for all models with helpers for serialization"""
 
-    def as_dict(
+    def to_dict(
         self, field_name: str = None
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
@@ -30,10 +32,17 @@ class ModelBase:
             raise Exception(f"Field {field_name} does not exist")
         return data
 
-    def as_json(self, **kwargs) -> str:
-        """Serialize the dataclass instance to JSON"""
-        return json_dumps(self.as_dict(**kwargs), default=str)
+    def to_dynamodb(self, **kwargs) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """Serialize the dataclass or field to a DynamoDB Item or list of Items"""
+        data = self.to_dict(**kwargs)
+        if isinstance(data, list):
+            return serialize_dynamodb_items(items=data)
+        return serialize_dynamodb_item(item=data)
 
-    def as_yaml(self, **kwargs) -> str:
+    def to_json(self, **kwargs) -> str:
+        """Serialize the dataclass instance to JSON"""
+        return json_dumps(self.to_dict(**kwargs), default=str)
+
+    def to_yaml(self, **kwargs) -> str:
         """Serialize the dataclass instance to YAML"""
-        return yaml_dump(self.as_dict(**kwargs))
+        return yaml_dump(self.to_dict(**kwargs))

--- a/aws_data_tools/models/organizations.py
+++ b/aws_data_tools/models/organizations.py
@@ -78,7 +78,7 @@ class Policy(ModelBase):
     tags: Dict[str, str] = field(default=None)
     targets: List[PolicyTargetSummary] = field(default=None)
 
-    def as_target(self):
+    def to_target(self):
         """Return the Policy as a PolicySummaryForTarget object"""
         return PolicySummaryForTarget(
             id=self.policy_summary.id, type=self.policy_summary.type
@@ -98,13 +98,13 @@ class Root(ModelBase):
     children: List[ParChild] = field(default=None)
     policies: List[PolicySummaryForTarget] = field(default=None)
 
-    def as_parchild_dict(self) -> Dict[str, str]:
+    def to_parchild_dict(self) -> Dict[str, str]:
         """Return the root as a ParChild (parent) dict"""
         return {"id": self.id, "type": "ROOT"}
 
-    def as_parchild(self) -> ParChild:
+    def to_parchild(self) -> ParChild:
         """Return the root as a ParChild (parent) object"""
-        return ParChild(**self.as_parchild_dict())
+        return ParChild(**self.to_parchild_dict())
 
 
 @dataclass
@@ -121,13 +121,13 @@ class OrganizationalUnit(ModelBase):
     policies: List[PolicySummaryForTarget] = field(default=None)
     tags: Dict[str, str] = field(default=None)
 
-    def as_parchild_dict(self) -> Dict[str, str]:
+    def to_parchild_dict(self) -> Dict[str, str]:
         """Return the OU as a ParChild (parent) dict"""
         return {"id": self.id, "type": "ORGANIZATIONAL_UNIT"}
 
-    def as_parchild(self) -> ParChild:
+    def to_parchild(self) -> ParChild:
         """Return the OU as a ParChild (parent) object"""
-        return ParChild(**self.as_parchild_dict())
+        return ParChild(**self.to_parchild_dict())
 
 
 @dataclass
@@ -148,13 +148,13 @@ class Account(ModelBase):
     policies: List[PolicySummaryForTarget] = field(default=None)
     tags: Dict[str, str] = field(default=None)
 
-    def as_parchild_dict(self) -> Dict[str, str]:
+    def to_parchild_dict(self) -> Dict[str, str]:
         """Return the account as a ParChild (parent) dict"""
         return {"id": self.id, "type": "ACCOUNT"}
 
-    def as_parchild(self) -> ParChild:
+    def to_parchild(self) -> ParChild:
         """Return the account as a ParChild (parent) object"""
-        return ParChild(**self.as_parchild_dict())
+        return ParChild(**self.to_parchild_dict())
 
 
 @dataclass
@@ -172,6 +172,12 @@ class Organization(ModelBase):
     master_account_id: str = field(default=None)
 
     # Optional properties generally populated after initialization
+
+    # TODO: These collections should be converted to container data classes to be able
+    # to better able to handle operations against specific fields. Currently,
+    # serializing/deserializing these collections indepently requires passing the
+    # "field_name" kwarg to the `to_dict()` function from ModelBase. It's already
+    # getting hacky.
     accounts: List[Account] = field(default=None)
     organizational_units: List[OrganizationalUnit] = field(default=None)
     policies: List[Policy] = field(default=None)

--- a/aws_data_tools/utils.py
+++ b/aws_data_tools/utils.py
@@ -1,4 +1,9 @@
-from typing import Dict, List
+"""
+Utilities for common operations that happen across different services
+"""
+from typing import Any, Dict, List
+
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 
 from .client import APIClient
 
@@ -14,3 +19,35 @@ def query_tags(client: APIClient, resource_id: str) -> Dict[str, str]:
     if len(tags) == 0:
         return {}
     return tag_list_to_dict(tags)
+
+
+def serialize_dynamodb_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a dict to a DynamoDB Item"""
+    serializer = TypeSerializer()
+    return {key: serializer.serialize(value) for key, value in item.items()}
+
+
+def serialize_dynamodb_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert a list of dicts to a list of DynamoDB Items"""
+    return [serialize_dynamodb_item(item) for item in items]
+
+
+def deserialize_dynamodb_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a DynamoDB Item to a dict"""
+    deserializer = TypeDeserializer()
+    return {key: deserializer.deserialize(value) for key, value in item.items()}
+
+
+def deserialize_dynamodb_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert a list of DynamoDB Items to a list of dicts"""
+    return [deserialize_dynamodb_item(item) for item in items]
+
+
+def prepare_dynamodb_batch_put_request(
+    table: str,
+    items: List[Dict[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Prepare PutRequest input for a DynamoDB BatchWriteItem request"""
+    return {
+        table: [{"PutRequest": {"Item": item}} for item in items if item is not None]
+    }


### PR DESCRIPTION
### Added

- Adds an `organizations write-accounts-to-dynamodb` CLI command
- Adds an `organizations read-accounts-from-dynamodb` CLI command
- Adds DynamoDB (de)serialization functions and requests helpers to utils

### Changed

- Updates the Makefile to allow setting a custom PYTHONBREAKPOINT when debugging
- Updates `OrganizationDataBuilder` to allow setting the client during init
- Updates `OrganizationDataBuilder` to allow excluding account parent data lookups
- Renames `ModelBase` serialization function prefixes from `as_` to `to_`
- Updates `APIClient.api()` to only pascalize keys in kwargs, not the values. This
  fixes a bug that was causing items being inserted into DynamoDB to be pascalized.
- Updates `APIClient()` and `APIClient.Connect()` to skip creating the client if it
  already exists