### PR TITLE
fix: Change Account datetime field to string to fix DynamoDB serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ Notes for any unreleased changes do here. When a new release is cut, move these 
 the unreleased section to the section for the new release.
 -->
 
-No unreleased changes.
+### Changed
+
+- Changed the `Account.joined_timestamp` field from datetime to str to fix DynamoDB
+  (de)serialization
+- Changed the `Organization` model to allow fields to be null for empty init
+- Fixes broken login in `ModelBase.to_dict()` when passing field_name, removes unused
+  flatten kwarg
+- Bumps ipython dev dependency due to vulnerability
 
 ## [0.1.1] - 2021-11-23
 

--- a/aws_data_tools/models/base.py
+++ b/aws_data_tools/models/base.py
@@ -26,7 +26,7 @@ class ModelBase:
         return from_dict(data_class=cls, data=decamelize(depascalize(data)))
 
     def to_dict(
-        self, field_name: str = None, flatten: bool = False
+        self, field_name: str = None
     ) -> Union[dict[str, Any], list[dict[str, Any]]]:  # pragma: no cover
         """
         Serialize the dataclass instance to a dict, or serialize a single field. If the
@@ -37,7 +37,7 @@ class ModelBase:
         if field_name is not None:
             if field_name in data.keys():
                 if isinstance(data[field_name], (dict, list)):
-                    return self.data[field_name]
+                    return data[field_name]
                 return {field_name: data[field_name]}
             raise Exception(f"Field {field_name} does not exist")
         return data

--- a/aws_data_tools/models/organizations.py
+++ b/aws_data_tools/models/organizations.py
@@ -2,7 +2,6 @@
 Dataclass builders and models for working with AWS Organizations APIs
 """
 
-from datetime import datetime
 from dataclasses import dataclass, field, InitVar
 import logging
 from typing import Any, Union
@@ -323,7 +322,7 @@ class Account(ModelBase):
     arn: str
     email: str
     id: str
-    joined_timestamp: datetime
+    joined_timestamp: str
     name: str
     joined_method: str
     status: str
@@ -347,13 +346,15 @@ class Account(ModelBase):
 class Organization(ModelBase):
     """Represents an organization and all it's nodes and edges"""
 
-    arn: str
-    available_policy_types: list[PolicyTypeSummary]
-    feature_set: str
-    id: str
-    master_account_arn: str
-    master_account_email: str
-    master_account_id: str
+    # We allow all these fields to default to None so we can support initializing an
+    # organization object with empty data.
+    arn: str = field(default=None)
+    available_policy_types: list[PolicyTypeSummary] = field(default=None)
+    feature_set: str = field(default=None)
+    id: str = field(default=None)
+    master_account_arn: str = field(default=None)
+    master_account_email: str = field(default=None)
+    master_account_id: str = field(default=None)
 
     # TODO: These collections should be converted to container data classes to be able
     # to better able to handle operations against specific fields. Currently,


### PR DESCRIPTION
This fixes a few bugs with organizations models, as well as one with ModelBase.

### Changed

- Changed the `Account.joined_timestamp` field from datetime to str to fix DynamoDB (de)serialization
- Changed the `Organization` model to allow fields to be null for empty init
- Fixes broken login in `ModelBase.to_dict()` when passing field_name, removes unused flatten kwarg

Closes #17
