### PR TITLE
fix: Properly cast Account.joined_timestamp to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,18 @@ Notes for any unreleased changes do here. When a new release is cut, move these 
 the unreleased section to the section for the new release.
 -->
 
+### Added
+
+- New extras available for installation: "graphviz" and "all."
+
 ### Changed
 
 - Changed the `Account.joined_timestamp` field from datetime to str to fix DynamoDB
-  (de)serialization
+  (de)serialization. Since boto3 returns the field as datetime, also added config to
+  from_dict() to cast it to string.
+- Updates `ModelBase.from_dict()` to accept and pass through kwargs
 - Changed the `Organization` model to allow fields to be null for empty init
-- Fixes broken login in `ModelBase.to_dict()` when passing field_name, removes unused
+- Fixes broken logic in `ModelBase.to_dict()` when passing field_name, removes unused
   flatten kwarg
 - Bumps ipython dev dependency due to vulnerability
 - Upgrades dependencies

--- a/aws_data_tools/models/base.py
+++ b/aws_data_tools/models/base.py
@@ -21,9 +21,9 @@ class ModelBase:
     """Base class for all models with helpers for serialization"""
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]):
+    def from_dict(cls, data: dict[str, Any], **kwargs):
         """Initialize the model from a dictionary"""
-        return from_dict(data_class=cls, data=decamelize(depascalize(data)))
+        return from_dict(data_class=cls, data=decamelize(depascalize(data)), **kwargs)
 
     def to_dict(
         self, field_name: str = None
@@ -70,7 +70,10 @@ class ModelBase:
         """Deserialize the JSON string to an instance of the dataclass"""
         # Try to remove any escape characters from the string based on the assumption
         # that it could be an escape characters
-        return cls.from_dict(json.loads(s.replace('\\"', '"').replace("\\n", "\n")))
+        return cls.from_dict(
+            json.loads(s.replace('\\"', '"').replace("\\n", "\n")),
+            **kwargs,
+        )
 
     def to_yaml(self, escape: bool = False, **kwargs) -> str:  # pragma: no cover
         """Serialize the dataclass instance to a YAML string"""
@@ -84,4 +87,4 @@ class ModelBase:
         """Deserialize the YAML string to an instance of the dataclass"""
         # Try to remove any escape characters from the string based on the assumption
         # that it could have escape characters
-        return cls.from_dict(yaml.safe_load(s.replace('\\"', '"')))
+        return cls.from_dict(yaml.safe_load(s.replace('\\"', '"')), **kwargs)

--- a/aws_data_tools/models/organizations.py
+++ b/aws_data_tools/models/organizations.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field, InitVar
 import logging
 from typing import Any, Union
 
+from dacite.config import Config
+
 try:
     import graphviz
 except ImportError:
@@ -342,6 +344,13 @@ class Account(ModelBase):
     def to_parchild(self) -> ParChild:
         """Return the account as a ParChild (parent) object"""
         return ParChild.from_dict(self.to_parchild_dict())
+
+    @classmethod
+    def from_dict(cls, *args, **kwargs):
+        # boto3 returns the "joined_method" as datetime.datetime, which can't
+        # serialize cleanly for DynamoDB. Passing this custom config tells dacite to
+        # cast any fields that are supposed to be strings to strings.
+        return super().from_dict(*args, config=Config(cast=[str]))
 
 
 class DependencyError(Exception):


### PR DESCRIPTION
In attempting to fix DynamoDB serialization for the `Account` model in #17, another bug
was introduced. This fixes it.

### Changed

- Adds configuration to `Account.from_dict()` to cast `joined_timestamp` to a string
- Updates `ModelBase.from_dict()` to accept and pass through kwargs